### PR TITLE
Update NuGet Setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,8 @@
+root=true
+
 [*]
 indent_style=space
 indent_size=2
+trim_trailing_spaces = true
+insert_final_newline = true
+charset = utf-8

--- a/MetaBrainz.Build.Sdk/Defaults.props
+++ b/MetaBrainz.Build.Sdk/Defaults.props
@@ -10,12 +10,14 @@
   <!-- Set up defaults for the frameworks to target. -->
   <PropertyGroup>
     <TargetFrameworks>
-      <!-- Target .NET Standard 2.1. This provides support for .NET Core 3.0 or later and .NET 5 or later. -->
+      <!-- Target .NET 6.0. This provides support for .NET 6.0 or later. -->
+      net6.0;
+      <!-- Target .NET Standard 2.1. This provides support for .NET Core 3.0 or later. -->
       netstandard2.1;
-      <!-- Also target .NET Standard 2.0. This provides support for .NET Core 2.0 or later. -->
+      <!-- Also target .NET Standard 2.0. This provides support for .NET Core 2.0 or later, and .NET Framework 4.7.2. -->
       netstandard2.0;
-      <!-- Target the .NET Framework too; should not be required but can be useful for compatibility. -->
-      net472
+      <!-- Target .NET Framework 4.8 too. -->
+      net48
     </TargetFrameworks>
   </PropertyGroup>
 

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -7,12 +7,12 @@
     <PackageTags>MetaBrainz msbuild sdk</PackageTags>
     <Product>MetaBrainz.Build</Product>
     <Title>MetaBrainz .NET SDK</Title>
-    <Version>1.0.2-pre</Version>
+    <Version>2.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- There's no actual code in this, but set a target anyway. -->
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MetaBrainz.Build.Sdk/NuGet.targets
+++ b/MetaBrainz.Build.Sdk/NuGet.targets
@@ -3,18 +3,20 @@
 
   <PropertyGroup>
     <PackageCopyrightYears Condition=" '$(PackageCopyrightYears)' == '' ">$([System.DateTime]::UtcNow.Year)</PackageCopyrightYears>
+    <PackageRepositoryName Condition=" '$(PackageRepositoryName)' == '' ">$(PackageId)</PackageRepositoryName>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PackageRepositoryName)' != '' ">
-    <Product Condition=" '$(Product)' == '' ">MetaBrainz.$(PackageRepositoryName)</Product>
+    <Product Condition=" '$(Product)' == '' ">$(PackageRepositoryName)</Product>
     <RepositoryUrl Condition=" '$(RepositoryUrl)' == '' ">https://github.com/Zastai/$(PackageRepositoryName)</RepositoryUrl>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(PackageProjectUrl)' == '' And '$(RepositoryUrl)' != '' And '$(DefaultProjectUrlToREADME)' != 'false' ">
+  <PropertyGroup Condition=" '$(PackageProjectUrl)' == '' And '$(RepositoryUrl)' != '' And '$(DefaultProjectUrlToReadMe)' != 'false' ">
     <PackageProjectUrl>$(RepositoryUrl)/blob/master/README.md</PackageProjectUrl>
   </PropertyGroup>
+  
+  <!-- If the project is packable, set up the package icon, ReadMe and license if not already done. -->
 
-  <!-- If the project is packable and does not specify a package icon, use the default icon. -->
   <Target Name="_SetUpDefaultPackageIcon" BeforeTargets="Build"
           Condition=" '$(IsPackable)' != 'False' And '$(PackageIcon)' == '' And Exists('$(MetaBrainzDefaultPackageIcon)') And '$(UseDefaultPackageIcon)' != 'false' ">
     <ItemGroup>
@@ -25,6 +27,29 @@
     </ItemGroup>
     <PropertyGroup>
       <PackageIcon>$([System.IO.Path]::GetFileName('$(MetaBrainzDefaultPackageIcon)'))</PackageIcon>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_SetUpPackageLicense" BeforeTargets="Build"
+          Condition=" '$(IsPackable)' != 'False' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') And '$(IncludeLicenseInPackage)' != 'false' ">
+    <ItemGroup>
+      <None Include="$(MetaBrainzProjectRoot)LICENSE.md">
+        <Pack>true</Pack>
+        <PackagePath/>
+      </None>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_SetUpPackageReadMe" BeforeTargets="Build"
+          Condition=" '$(IsPackable)' != 'False' And '$(PackageReadMeFile)' == '' And Exists('$(MetaBrainzProjectRoot)README.md') And '$(IncludeReadMeInPackage)' != 'false' ">
+    <ItemGroup>
+      <None Include="$(MetaBrainzProjectRoot)README.md">
+        <Pack>true</Pack>
+        <PackagePath/>
+      </None>
+    </ItemGroup>
+    <PropertyGroup>
+      <PackageReadMeFile>README.md</PackageReadMeFile>
     </PropertyGroup>
   </Target>
 

--- a/MetaBrainz.Build.sln
+++ b/MetaBrainz.Build.sln
@@ -7,6 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetaBrainz.Build.Sdk", "Met
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{C9D2F120-3CEA-499A-B5BD-DFF6684631A4}"
 ProjectSection(SolutionItems) = preProject
+	.editorconfig = .editorconfig
 	appveyor.yml = appveyor.yml
 	Directory.Build.props = Directory.Build.props
 	Directory.Build.targets = Directory.Build.targets

--- a/MetaBrainz.Build.sln
+++ b/MetaBrainz.Build.sln
@@ -15,6 +15,14 @@ ProjectSection(SolutionItems) = preProject
 	README.md = README.md
 EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Initial Project Contents", "Initial Project Contents", "{274B380A-F4E4-4CC8-9D12-BA867ED3B46E}"
+ProjectSection(SolutionItems) = preProject
+	initial-project-contents\.editorconfig = initial-project-contents\.editorconfig
+	initial-project-contents\.gitattributes = initial-project-contents\.gitattributes
+	initial-project-contents\.gitignore = initial-project-contents\.gitignore
+	initial-project-contents\appveyor.yml = initial-project-contents\appveyor.yml
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/MetaBrainz.Build.sln
+++ b/MetaBrainz.Build.sln
@@ -14,6 +14,7 @@ ProjectSection(SolutionItems) = preProject
 	Directory.Packages.props = Directory.Packages.props
 	LICENSE.md = LICENSE.md
 	README.md = README.md
+	build-package.ps1 = build-package.ps1
 EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Initial Project Contents", "Initial Project Contents", "{274B380A-F4E4-4CC8-9D12-BA867ED3B46E}"
@@ -22,6 +23,7 @@ ProjectSection(SolutionItems) = preProject
 	initial-project-contents\.gitattributes = initial-project-contents\.gitattributes
 	initial-project-contents\.gitignore = initial-project-contents\.gitignore
 	initial-project-contents\appveyor.yml = initial-project-contents\appveyor.yml
+	initial-project-contents\build-package.ps1 = initial-project-contents\build-package.ps1
 EndProjectSection
 EndProject
 Global

--- a/MetaBrainz.Build.sln
+++ b/MetaBrainz.Build.sln
@@ -5,6 +5,16 @@ VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetaBrainz.Build.Sdk", "MetaBrainz.Build.Sdk\MetaBrainz.Build.Sdk.csproj", "{20B49106-BE37-4358-8BBB-7DDD6443B0AA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{C9D2F120-3CEA-499A-B5BD-DFF6684631A4}"
+ProjectSection(SolutionItems) = preProject
+	appveyor.yml = appveyor.yml
+	Directory.Build.props = Directory.Build.props
+	Directory.Build.targets = Directory.Build.targets
+	Directory.Packages.props = Directory.Packages.props
+	LICENSE.md = LICENSE.md
+	README.md = README.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 This used to be a collection of build support files, pulled in (as a git
 submodule) by other `MetaBrainz.xxx` projects.
 
-However, it has since been upgraded to be a separate project that produces
-an MSBuild SDK package, setting up the same thing, but without needing
-submodules.
+However, it has since been upgraded to be a separate project that
+produces an MSBuild SDK package, setting up the same thing, but without
+needing submodules.
 
 ## Contents
 
@@ -22,12 +22,24 @@ This consists of:
 - a default package icon (using the basic MetaBrainz logo)
 - the strong naming key to be used
 
-At some point, this could be extended to include MSBuild tasks, should they
-become useful; in the meantime, there is no code present.
+At some point, this could be extended to include MSBuild tasks, should
+they become useful; in the meantime, there is no code present.
 
 ## Release Notes
 
-### v1.0.2 (not yet released)
+### v2.0.0 (not yet released)
+
+- `PackageRepositoryName` now defaults to `$(PackageId)`.
+- `Product` is no longer set to `$(PackageRepositoryName)` with an extra
+ `MetaBrainz.` prefix.
+- `PackageReadMeFile` is defaulted to the `README.md` in the project
+  tree or the package root.
+- `net6.0` has been added to the set of default targets.
+` the `net472` target has been bumped to `net48`.
+  - `net472` is already covered by `netstandard2.0`.
+- Updated the initial project contents.
+- Use the `Visual Studio 2022` image for AppVeyor builds.
+- Added a "build package" script.
 
 ### v1.0.1 (2021-08-05)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
+version: 'Build #{build}'
 image: Visual Studio 2019
-configuration: Debug
 before_build:
-- cmd: dotnet restore
-build:
-  publish_nuget: true
-  publish_nuget_symbols: false
-  parallel: true
-  verbosity: minimal
+  - ps: dotnet restore
+build_script:
+  - ps: dotnet pack --nologo --no-restore -c:Debug '-p:Deterministic=true' '-p:ContinuousIntegrationBuild=true'
+after_build:
+  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: 'Build #{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 before_build:
-  - ps: dotnet restore
+- ps: dotnet restore
 build_script:
-  - ps: dotnet pack --nologo --no-restore -c:Debug '-p:Deterministic=true' '-p:ContinuousIntegrationBuild=true'
+- ps: dotnet pack --nologo --no-restore -c:Debug '-p:Deterministic=true' '-p:ContinuousIntegrationBuild=true'
 after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }
+- ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -1,0 +1,25 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param (
+  [string] $Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (Test-Path -Path output) {
+  Write-Host 'Cleaning up existing build output...'
+  Remove-Item -Recurse output
+}
+
+Write-Host "Running package restore..."
+dotnet restore
+
+Write-Host "Building the solution ($Configuration mode)..."
+dotnet build --nologo --no-restore -c:$Configuration '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+
+Write-Host "Running tests..."
+dotnet test --nologo --no-build -c:$Configuration
+
+Write-Host "Creating packages..."
+dotnet pack --nologo --no-build -c:$Configuration

--- a/initial-project-contents/.gitignore
+++ b/initial-project-contents/.gitignore
@@ -2,8 +2,6 @@
 /.vs/
 /.vscode/
 /output/
-/Directory.Build.Local.props
-/Directory.Build.Local.targets
 /msbuild.binlog
 *.*proj.user
 *.DotSettings.user

--- a/initial-project-contents/appveyor.yml
+++ b/initial-project-contents/appveyor.yml
@@ -1,5 +1,5 @@
 version: 'Build #{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 before_build:
 - ps: dotnet restore
 build_script:

--- a/initial-project-contents/appveyor.yml
+++ b/initial-project-contents/appveyor.yml
@@ -1,11 +1,8 @@
-version: 1.0.0-appveyor.{build}
+version: 'Build #{build}'
 image: Visual Studio 2019
-configuration: Debug
 before_build:
-- cmd: dotnet restore
-build:
-  publish_nuget: true
-  publish_nuget_symbols: true
-  use_snupkg_format: true
-  parallel: true
-  verbosity: minimal
+- ps: dotnet restore
+build_script:
+- ps: dotnet pack --nologo --no-restore -c:Debug '-p:Deterministic=true' '-p:ContinuousIntegrationBuild=true'
+after_build:
+- ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/initial-project-contents/build-package.ps1
+++ b/initial-project-contents/build-package.ps1
@@ -1,0 +1,25 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param (
+  [string] $Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (Test-Path -Path output) {
+  Write-Host 'Cleaning up existing build output...'
+  Remove-Item -Recurse output
+}
+
+Write-Host "Running package restore..."
+dotnet restore
+
+Write-Host "Building the solution ($Configuration mode)..."
+dotnet build --nologo --no-restore -c:$Configuration '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+
+Write-Host "Running tests..."
+dotnet test --nologo --no-build -c:$Configuration
+
+Write-Host "Creating packages..."
+dotnet pack --nologo --no-build -c:$Configuration


### PR DESCRIPTION
- `PackageRepositoryName` now defaults to `$(PackageId)`.
- `Product` is no longer set to `$(PackageRepositoryName)` with an extra `MetaBrainz.` prefix.
- `PackageReadMeFile` is defaulted to the `README.md` in the project tree or the package root.
- `net6.0` has been added to the set of default targets.
- The `net472` target has been bumped to `net48`.
  - `net472` is already covered by `netstandard2.0`.
- Updated the initial project contents.
- Use the `Visual Studio 2022` image for AppVeyor builds.
- Added a "build package" script.