### PR TITLE
Fix copyright setup

### DIFF
--- a/MetaBrainz.Build.Sdk/NuGet.props
+++ b/MetaBrainz.Build.Sdk/NuGet.props
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <Authors>Zastai</Authors>
     <Company>MetaBrainz</Company>
-    <Copyright>Copyright © $(PackageCopyrightYears) Tim Van Holder. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>Github</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/MetaBrainz.Build.Sdk/NuGet.targets
+++ b/MetaBrainz.Build.Sdk/NuGet.targets
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
+  <!-- Set Up Copyright Info -->
+  
   <PropertyGroup>
     <PackageCopyrightYears Condition=" '$(PackageCopyrightYears)' == '' ">$([System.DateTime]::UtcNow.Year)</PackageCopyrightYears>
+    <Copyright Condition=" '$(Copyright)' == '' ">Copyright © $(PackageCopyrightYears) Tim Van Holder. All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <!-- Set Up Package Info -->
+  
+  <PropertyGroup>
     <PackageRepositoryName Condition=" '$(PackageRepositoryName)' == '' ">$(PackageId)</PackageRepositoryName>
   </PropertyGroup>
 


### PR DESCRIPTION
`Copyright` was being defaulted in NuGet.props, but it included `$(PackageCopyrightYears)` before it was set.
It has now been moved to NuGet.targets, after the defaulting of `$(PackageCopyrightYears)`.