### PR TITLE
Fix ReadMe file setup

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,6 +8,8 @@
 
   <Import Project="MetaBrainz.Build.Sdk\NuGet.targets" />
 
+  <Import Project="MetaBrainz.Build.Sdk\TreeStructure.targets" />
+
   <Import Project="MetaBrainz.Build.Sdk\Versioning.targets" />
         
   <!-- Get local (user-specific, non-version-controlled) targets. -->

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -30,10 +30,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="MetaBrainz.snk"/>
-    <Content Include="package-icon.png"/>
-    <Content Include="*.props"/>
-    <Content Include="*.targets"/>
+    <Content Include="MetaBrainz.snk" />
+    <Content Include="package-icon.png" />
+    <Content Include="*.props" />
+    <Content Include="*.targets" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.Build.Sdk/NuGet.targets
+++ b/MetaBrainz.Build.Sdk/NuGet.targets
@@ -44,23 +44,23 @@
       <_LicenseIncluded>false</_LicenseIncluded>
     </PropertyGroup>
     <!-- Check for a project-level license file. -->
-    <ItemGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('LICENSE.md') ">
+    <ItemGroup Condition=" '$(_LicenseIncluded)' != 'true' And Exists('LICENSE.md') ">
       <None Include="LICENSE.md">
         <Pack>true</Pack>
-        <PackagePath/>
+        <PackagePath>LICENSE.md</PackagePath>
       </None>
     </ItemGroup>
-    <PropertyGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('LICENSE.md') ">
+    <PropertyGroup Condition=" '$(_LicenseIncluded)' != 'true' And Exists('LICENSE.md') ">
       <_LicenseIncluded>true</_LicenseIncluded>
     </PropertyGroup>
     <!-- Check for a solution-level license file. -->
-    <ItemGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') ">
+    <ItemGroup Condition=" '$(_LicenseIncluded)' != 'true' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') ">
       <None Include="$(MetaBrainzProjectRoot)LICENSE.md">
         <Pack>true</Pack>
-        <PackagePath/>
+        <PackagePath>LICENSE.md</PackagePath>
       </None>
     </ItemGroup>
-    <PropertyGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') ">
+    <PropertyGroup Condition=" '$(_LicenseIncluded)' != 'true' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') ">
       <_LicenseIncluded>true</_LicenseIncluded>
     </PropertyGroup>
   </Target>

--- a/MetaBrainz.Build.Sdk/NuGet.targets
+++ b/MetaBrainz.Build.Sdk/NuGet.targets
@@ -39,24 +39,62 @@
   </Target>
 
   <Target Name="_SetUpPackageLicense" BeforeTargets="Build"
-          Condition=" '$(IsPackable)' != 'False' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') And '$(IncludeLicenseInPackage)' != 'false' ">
-    <ItemGroup>
+          Condition=" '$(IsPackable)' != 'False' And '$(IncludeLicenseInPackage)' != 'false' ">
+    <PropertyGroup>
+      <_LicenseIncluded>false</_LicenseIncluded>
+    </PropertyGroup>
+    <!-- Check for a project-level license file. -->
+    <ItemGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('LICENSE.md') ">
+      <None Include="LICENSE.md">
+        <Pack>true</Pack>
+        <PackagePath/>
+      </None>
+    </ItemGroup>
+    <PropertyGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('LICENSE.md') ">
+      <_LicenseIncluded>true</_LicenseIncluded>
+    </PropertyGroup>
+    <!-- Check for a solution-level license file. -->
+    <ItemGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') ">
       <None Include="$(MetaBrainzProjectRoot)LICENSE.md">
         <Pack>true</Pack>
         <PackagePath/>
       </None>
     </ItemGroup>
+    <PropertyGroup Condition=" $(_LicenseIncluded) != 'true' And Exists('$(MetaBrainzProjectRoot)LICENSE.md') ">
+      <_LicenseIncluded>true</_LicenseIncluded>
+    </PropertyGroup>
   </Target>
 
   <Target Name="_SetUpPackageReadMe" BeforeTargets="Build"
-          Condition=" '$(IsPackable)' != 'False' And '$(PackageReadMeFile)' == '' And Exists('$(MetaBrainzProjectRoot)README.md') And '$(IncludeReadMeInPackage)' != 'false' ">
-    <ItemGroup>
-      <None Include="$(MetaBrainzProjectRoot)README.md">
+          Condition=" '$(IsPackable)' != 'False' And '$(PackageReadMeFile)' == '' And '$(IncludeReadMeInPackage)' != 'false' ">
+    <!-- Check for a project-level README file. -->
+    <ItemGroup Condition=" '$(PackageReadMeFile)' == '' And Exists('README.md') ">
+      <None Include="README.md">
         <Pack>true</Pack>
-        <PackagePath/>
+        <PackagePath>README.md</PackagePath>
       </None>
     </ItemGroup>
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(PackageReadMeFile)' == '' And Exists('README.md') ">
+      <PackageReadMeFile>README.md</PackageReadMeFile>
+    </PropertyGroup>
+    <!-- Check for a solution-level package README file. -->
+    <ItemGroup Condition=" '$(PackageReadMeFile)' == '' And Exists('$(MetaBrainzProjectRoot)README.Package.md') ">
+      <None Include="$(MetaBrainzProjectRoot)README.Package.md">
+        <Pack>true</Pack>
+        <PackagePath>README.md</PackagePath>
+      </None>
+    </ItemGroup>
+    <PropertyGroup Condition=" '$(PackageReadMeFile)' == '' And Exists('$(MetaBrainzProjectRoot)README.Package.md') ">
+      <PackageReadMeFile>README.md</PackageReadMeFile>
+    </PropertyGroup>
+    <!-- Fall back on the solution-level README file. -->
+    <ItemGroup Condition=" '$(PackageReadMeFile)' == '' And Exists('$(MetaBrainzProjectRoot)README.md') ">
+      <None Include="$(MetaBrainzProjectRoot)README.md">
+        <Pack>true</Pack>
+        <PackagePath>README.md</PackagePath>
+      </None>
+    </ItemGroup>
+    <PropertyGroup Condition=" '$(PackageReadMeFile)' == '' And Exists('$(MetaBrainzProjectRoot)README.md') ">
       <PackageReadMeFile>README.md</PackageReadMeFile>
     </PropertyGroup>
   </Target>

--- a/MetaBrainz.Build.Sdk/Sdk.targets
+++ b/MetaBrainz.Build.Sdk/Sdk.targets
@@ -3,6 +3,8 @@
 
   <Import Project="NuGet.targets" />
 
+  <Import Project="TreeStructure.targets" />
+
   <Import Project="Versioning.targets" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/MetaBrainz.Build.Sdk/TreeStructure.props
+++ b/MetaBrainz.Build.Sdk/TreeStructure.props
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <!-- Use README.md to identify the project root. -->
+  <!-- Use the build script to identify the project root. -->
   <PropertyGroup>
-    <MetaBrainzProjectRoot>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', 'README.md'))))</MetaBrainzProjectRoot>
+    <MetaBrainzProjectRootTriggerFile>build-package.ps1</MetaBrainzProjectRootTriggerFile>
+    <MetaBrainzProjectRoot>$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', '$(MetaBrainzProjectRootTriggerFile)'))</MetaBrainzProjectRoot>
+    <MetaBrainzProjectRoot>$([MSBuild]::EnsureTrailingSlash('$(MetaBrainzProjectRoot)'))</MetaBrainzProjectRoot>
   </PropertyGroup>
 
   <!-- Set up the build output locations (only if the project root was found). -->

--- a/MetaBrainz.Build.Sdk/TreeStructure.targets
+++ b/MetaBrainz.Build.Sdk/TreeStructure.targets
@@ -8,6 +8,13 @@
     <!-- This should be impossible. -->
     <Error Text="The root folder for this build was determined to be '$(MetaBrainzProjectRoot)', but it does not exist."
            Condition=" !Exists('$(MetaBrainzProjectRoot)') " />
+    <!-- The build root is required to contain a few specific files. -->
+    <ItemGroup>
+      <_RequiredMetaBrainzProjectRootContents Include="LICENSE.md" />
+      <_RequiredMetaBrainzProjectRootContents Include="README.md" />
+    </ItemGroup>
+    <Error Text="The root folder for this build was determined to be '$(MetaBrainzProjectRoot)', but it does not contain a '%(_RequiredMetaBrainzProjectRootContents.Identity)' file."
+           Condition=" !Exists('$(MetaBrainzProjectRoot)%(_RequiredMetaBrainzProjectRootContents.Identity)') " />
   </Target>
 
 </Project>

--- a/MetaBrainz.Build.Sdk/TreeStructure.targets
+++ b/MetaBrainz.Build.Sdk/TreeStructure.targets
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- 'Restore' does not work reliably in BeforeTargets, but 'CollectPackageReferences' triggers nicely. -->
+  <Target Name="_VerifyRootFolder" BeforeTargets="CollectPackageReferences">
+    <Error Text="Could not determine the root folder for this build; is a '$(MetaBrainzProjectRootTriggerFile)' file present?"
+           Condition=" '$(MetaBrainzProjectRoot)' == '' " />
+    <!-- This should be impossible. -->
+    <Error Text="The root folder for this build was determined to be '$(MetaBrainzProjectRoot)', but it does not exist."
+           Condition=" !Exists('$(MetaBrainzProjectRoot)') " />
+  </Target>
+
+</Project>


### PR DESCRIPTION
The top-level folder is now determined based on the `build-package.ps1` file.
If not found, or if it does not contain both `LICENSE.md` and `README.md`, a build error is now provoked.

Packaging changes:
- LICENSE.md is now taken from the project folder if it exists there.
- For the package ReadMe, the following are now considered:
  - a `README.md` file in the project directory
  - a top-level `README.Package.md` file
  - a top-level `README.md` file
    - this is a fallback, because it's intended for GitHub use