### PR TITLE
Adjust package build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vscode/
 /output/
 msbuild.binlog
+msbuild.*.binlog
 *.*proj.user
 *.DotSettings.user
 *.userprefs

--- a/MetaBrainz.Build.Sdk/CSharp.props
+++ b/MetaBrainz.Build.Sdk/CSharp.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -17,7 +17,6 @@
 
   <PropertyGroup>
     <ContentTargetFolders>Sdk</ContentTargetFolders>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeContent>true</IncludeContent>
   </PropertyGroup>
 

--- a/MetaBrainz.Build.Sdk/NuGet.props
+++ b/MetaBrainz.Build.Sdk/NuGet.props
@@ -20,10 +20,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-  </PropertyGroup>
-
   <!-- Use PackageReference, managing versions via Directory.Packages.props. -->
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/MetaBrainz.Build.Sdk/NuGet.targets
+++ b/MetaBrainz.Build.Sdk/NuGet.targets
@@ -25,7 +25,7 @@
   
   <!-- If the project is packable, set up the package icon, ReadMe and license if not already done. -->
 
-  <Target Name="_SetUpDefaultPackageIcon" BeforeTargets="Build"
+  <Target Name="_MaybeSetPackageIcon"
           Condition=" '$(IsPackable)' != 'False' And '$(PackageIcon)' == '' And Exists('$(MetaBrainzDefaultPackageIcon)') And '$(UseDefaultPackageIcon)' != 'false' ">
     <ItemGroup>
       <None Include="$(MetaBrainzDefaultPackageIcon)">
@@ -38,7 +38,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_SetUpPackageLicense" BeforeTargets="Build"
+  <Target Name="_MaybeSetPackageLicense"
           Condition=" '$(IsPackable)' != 'False' And '$(IncludeLicenseInPackage)' != 'false' ">
     <PropertyGroup>
       <_LicenseIncluded>false</_LicenseIncluded>
@@ -65,7 +65,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_SetUpPackageReadMe" BeforeTargets="Build"
+  <Target Name="_MaybeSetPackageReadMe" BeforeTargets="Build"
           Condition=" '$(IsPackable)' != 'False' And '$(PackageReadMeFile)' == '' And '$(IncludeReadMeInPackage)' != 'false' ">
     <!-- Check for a project-level README file. -->
     <ItemGroup Condition=" '$(PackageReadMeFile)' == '' And Exists('README.md') ">
@@ -98,5 +98,10 @@
       <PackageReadMeFile>README.md</PackageReadMeFile>
     </PropertyGroup>
   </Target>
+
+  <!-- Using BeforeTargets="Pack" for these targets does not work when using 'dotnet pack', but this does. -->
+  <PropertyGroup>
+    <BeforePack>_MaybeSetPackageIcon;_MaybeSetPackageLicense;_MaybeSetPackageReadMe;$(BeforePack)</BeforePack>
+  </PropertyGroup>
 
 </Project>

--- a/MetaBrainz.Build.sln
+++ b/MetaBrainz.Build.sln
@@ -8,6 +8,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{C9D2F120-3CEA-499A-B5BD-DFF6684631A4}"
 ProjectSection(SolutionItems) = preProject
 	.editorconfig = .editorconfig
+	.gitattributes = .gitattributes
+	.gitignore = .gitignore
 	appveyor.yml = appveyor.yml
 	Directory.Build.props = Directory.Build.props
 	Directory.Build.targets = Directory.Build.targets

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 version: 'Build #{build}'
 image: Visual Studio 2022
-before_build:
-- ps: dotnet restore
 build_script:
-- ps: dotnet pack --nologo --no-restore -c:Debug '-p:Deterministic=true' '-p:ContinuousIntegrationBuild=true'
+  - ps: .\build-package.ps1 -Configuration Debug
 after_build:
-- ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }
+  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -2,24 +2,61 @@
 
 [CmdletBinding()]
 param (
-  [string] $Configuration = 'Release'
+  [string] $Configuration = 'Release',
+  [switch] $WithBinLog = $false
 )
+
+$opts = @( '--nologo' )
+if ($WithBinLog) {
+  $opts += '-bl'
+}
 
 $ErrorActionPreference = 'Stop'
 
+function Complete-BuildStep {
+  param (
+    [string] $BinLogKeyword,
+    [string] $FailureTerm
+  )
+  if (Test-Path msbuild.binlog) {
+    if (Test-Path msbuild.$BinLogKeyword.binlog) {
+      Remove-Item -Force msbuild.$BinLogKeyword.binlog
+    }
+    Rename-Item msbuild.binlog msbuild.$BinLogKeyword.binlog
+  }
+  Write-Host ''
+}
+
 if (Test-Path -Path output) {
   Write-Host 'Cleaning up existing build output...'
-  Remove-Item -Recurse output
+  Remove-Item -Recurse -Force output
+  Write-Host ''
 }
 
 Write-Host "Running package restore..."
-dotnet restore
+dotnet restore $opts
+Complete-BuildStep 'restore'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "PACKAGE RESTORE FAILED"
+}
 
-Write-Host "Building the solution ($Configuration mode)..."
-dotnet build --nologo --no-restore -c:$Configuration '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+Write-Host "Building the solution (Configuration: $Configuration)..."
+dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+Complete-BuildStep 'build'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "SOLUTION BUILD FAILED"
+}
 
-Write-Host "Running tests..."
-dotnet test --nologo --no-build -c:$Configuration
+Write-Host 'Running tests...'
+dotnet test $opts --no-build "-c:$Configuration"
+Complete-BuildStep 'test'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "UNIT TESTS FAILED"
+}
 
-Write-Host "Creating packages..."
-dotnet pack --nologo --no-build -c:$Configuration
+Write-Host 'Creating packages...'
+dotnet pack $opts --no-build "-c:$Configuration"
+Complete-BuildStep 'pack'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "PACKAGE CREATION FAILED"
+}

--- a/initial-project-contents/.gitignore
+++ b/initial-project-contents/.gitignore
@@ -2,7 +2,8 @@
 /.vs/
 /.vscode/
 /output/
-/msbuild.binlog
+msbuild.binlog
+msbuild.*.binlog
 *.*proj.user
 *.DotSettings.user
 *.userprefs

--- a/initial-project-contents/appveyor.yml
+++ b/initial-project-contents/appveyor.yml
@@ -1,8 +1,6 @@
 version: 'Build #{build}'
 image: Visual Studio 2022
-before_build:
-- ps: dotnet restore
 build_script:
-- ps: dotnet pack --nologo --no-restore -c:Debug '-p:Deterministic=true' '-p:ContinuousIntegrationBuild=true'
+  - ps: .\build-package.ps1 -Configuration Debug
 after_build:
-- ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }
+  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/initial-project-contents/build-package.ps1
+++ b/initial-project-contents/build-package.ps1
@@ -2,24 +2,61 @@
 
 [CmdletBinding()]
 param (
-  [string] $Configuration = 'Release'
+  [string] $Configuration = 'Release',
+  [switch] $WithBinLog = $false
 )
+
+$opts = @( '--nologo' )
+if ($WithBinLog) {
+  $opts += '-bl'
+}
 
 $ErrorActionPreference = 'Stop'
 
+function Complete-BuildStep {
+  param (
+    [string] $BinLogKeyword,
+    [string] $FailureTerm
+  )
+  if (Test-Path msbuild.binlog) {
+    if (Test-Path msbuild.$BinLogKeyword.binlog) {
+      Remove-Item -Force msbuild.$BinLogKeyword.binlog
+    }
+    Rename-Item msbuild.binlog msbuild.$BinLogKeyword.binlog
+  }
+  Write-Host ''
+}
+
 if (Test-Path -Path output) {
   Write-Host 'Cleaning up existing build output...'
-  Remove-Item -Recurse output
+  Remove-Item -Recurse -Force output
+  Write-Host ''
 }
 
 Write-Host "Running package restore..."
-dotnet restore
+dotnet restore $opts
+Complete-BuildStep 'restore'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "PACKAGE RESTORE FAILED"
+}
 
-Write-Host "Building the solution ($Configuration mode)..."
-dotnet build --nologo --no-restore -c:$Configuration '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+Write-Host "Building the solution (Configuration: $Configuration)..."
+dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+Complete-BuildStep 'build'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "SOLUTION BUILD FAILED"
+}
 
-Write-Host "Running tests..."
-dotnet test --nologo --no-build -c:$Configuration
+Write-Host 'Running tests...'
+dotnet test $opts --no-build "-c:$Configuration"
+Complete-BuildStep 'test'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "UNIT TESTS FAILED"
+}
 
-Write-Host "Creating packages..."
-dotnet pack --nologo --no-build -c:$Configuration
+Write-Host 'Creating packages...'
+dotnet pack $opts --no-build "-c:$Configuration"
+Complete-BuildStep 'pack'
+if ($LASTEXITCODE -ne 0) {
+  Write-Error "PACKAGE CREATION FAILED"
+}


### PR DESCRIPTION
This improves the build script (better error handling, and support for building with binary logging) and uses it for AppVeyor builds.

Packages are no longer created as part of the build (with the icon/license/readme processing updated to handle that scenario).

The C# language version is increased from 9 to 10.