### PR TITLE
Fix release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,7 +19,7 @@ categories:
       - enhancement
       - feature
   - title: 🐛 Bug Fixes
-    labels: fix
+    label: fix
   - title: 📦 Dependency Updates
     label: dependencies # Used by Dependabot
   - title: 📝 Documentation Updates

--- a/initial-project-contents/.github/release-drafter.yml
+++ b/initial-project-contents/.github/release-drafter.yml
@@ -19,7 +19,7 @@ categories:
       - enhancement
       - feature
   - title: 🐛 Bug Fixes
-    labels: fix
+    label: fix
   - title: 📦 Dependency Updates
     label: dependencies # Used by Dependabot
   - title: 📝 Documentation Updates


### PR DESCRIPTION
This fixes a small syntax issue (passing a single string to `labels`; changed to just `label`).