### PR TITLE
Use GH Actions for CI builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "nuget"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "gh-actions"

--- a/.github/github-labels.yml
+++ b/.github/github-labels.yml
@@ -36,6 +36,14 @@
   color: '008672'
   description: "Changes related to unit tests"
 
+# Additional Labels Used by Dependabot
+- name: gh-actions
+  color: '1d0128'
+  description: "Version updates for GitHub actions"
+- name: nuget
+  color: '1d0128'
+  description: "Version updates for NuGet packages"
+
 # Additional Labels for Release Drafter Version Resolution
 - name: bump-major-version
   color: 'cf996b'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v3
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: NuGet Packages"
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet Packages (${{matrix.configuration}})
+        path: "**/bin/${{matrix.configuration}}/*.nupkg"
+    - name: Publish (NuGet - GitHub Packages)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,10 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: NuGet Packages (${{matrix.configuration}})
-        path: "**/bin/${{matrix.configuration}}/*.nupkg"
+        path: "output/package/${{matrix.configuration}}/*.nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
     - name: Publish (NuGet - nuget.org)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/MetaBrainz.Build.Sdk/Versioning.targets
+++ b/MetaBrainz.Build.Sdk/Versioning.targets
@@ -53,9 +53,11 @@
       <_CIBuildPackageInfo>appveyor.$(APPVEYOR_BUILD_NUMBER)</_CIBuildPackageInfo>
     </PropertyGroup>
     <!-- CI: GitHub Actions -->
-    <PropertyGroup Condition=" '$(CI)' == 'true' And '$(GITHUB_ACTIONS)' == 'true' And '$(GITHUB_RUN_ATTEMPT)' != '' ">
-      <_CIBuildInfo>GitHub build #$(GITHUB_RUN_ATTEMPT)</_CIBuildInfo>
-      <_CIBuildPackageInfo>github.$(GITHUB_RUN_ATTEMPT)</_CIBuildPackageInfo>
+    <PropertyGroup Condition=" '$(CI)' == 'true' And '$(GITHUB_ACTIONS)' == 'true' And '$(GITHUB_RUN_NUMBER)' != '' ">
+      <_CIBuildInfo>GitHub build #$(GITHUB_RUN_NUMBER)</_CIBuildInfo>
+      <_CIBuildInfo Condition=" '$(GITHUB_RUN_ATTEMPT)' != '' And '$(GITHUB_RUN_ATTEMPT)' != '1' ">$(_CIBuildInfo), attempt #$(GITHUB_RUN_ATTEMPT)</_CIBuildInfo>
+      <_CIBuildPackageInfo>github.$(GITHUB_RUN_NUMBER)</_CIBuildPackageInfo>
+      <_CIBuildPackageInfo Condition=" '$(GITHUB_RUN_ATTEMPT)' != '' ">$(_CIBuildPackageInfo).$(GITHUB_RUN_ATTEMPT)</_CIBuildPackageInfo>
     </PropertyGroup>
     <!-- FIXME: If no CI applies, should this be flagged in metadata? -->
   </Target>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - ps: .\build-package.ps1 -Configuration Debug
-after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }


### PR DESCRIPTION
Enables CI builds, including automatic deployment to GH Packages and nuget.org for tagged release builds.
Once verified as working, AppVeyor will be dropped.

This also enables Dependabot for the repository.
