### PR TITLE
Generate more assembly attributes

### DIFF
--- a/MetaBrainz.Build.Sdk/AssemblyInfo.targets
+++ b/MetaBrainz.Build.Sdk/AssemblyInfo.targets
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Set up attributes not (always) handled by the SDK. -->
+  <Target Name="_GetMoreAssemblyAttributes" AfterTargets="GetAssemblyAttributes" Condition=" '$(GenerateAssemblyInfo)' == 'true' ">
+
+    <PropertyGroup>
+      <GenerateAssemblyCLSCompliantAttributes Condition=" '' == '$(GenerateAssemblyCLSCompliantAttributes)' ">true</GenerateAssemblyCLSCompliantAttributes>
+      <GenerateAssemblyComVisibleAttributes   Condition=" '' == '$(GenerateAssemblyComVisibleAttributes)'   ">true</GenerateAssemblyComVisibleAttributes>
+      <GenerateAssemblyCultureAttributes      Condition=" '' == '$(GenerateAssemblyCultureAttributes)'      ">true</GenerateAssemblyCultureAttributes>
+      <GenerateAssemblyGuidAttributes         Condition=" '' == '$(GenerateAssemblyGuidAttributes)'         ">true</GenerateAssemblyGuidAttributes>
+      <GenerateAssemblyTrademarkAttributes    Condition=" '' == '$(GenerateAssemblyTrademarkAttributes)'    ">true</GenerateAssemblyTrademarkAttributes>
+    </PropertyGroup>
+
+    <ItemGroup Condition=" '$(GenerateAssemblyCLSCompliantAttributes)' == 'true' And '$(AssemblyIsCLSCompliant)' != '' ">
+      <AssemblyAttribute Include="System.CLSCompliantAttribute">
+        <_Parameter1>$(AssemblyIsCLSCompliant)</_Parameter1>
+        <_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
+      </AssemblyAttribute>
+    </ItemGroup>  
+
+    <ItemGroup Condition=" '$(GenerateAssemblyComVisibleAttributes)' == 'true' And '$(AssemblyIsComVisible)' != '' ">
+      <AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
+        <_Parameter1>$(AssemblyIsComVisible)</_Parameter1>
+        <_Parameter1_TypeName>System.Boolean</_Parameter1_TypeName>
+      </AssemblyAttribute>
+    </ItemGroup>  
+
+    <ItemGroup Condition=" '$(GenerateAssemblyCultureAttributes)' == 'true' And '$(AssemblyCulture)' != '' ">
+      <AssemblyAttribute Include="System.Reflection.AssemblyCultureAttribute">
+        <_Parameter1>$(AssemblyCulture)</_Parameter1>
+        <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
+      </AssemblyAttribute>
+    </ItemGroup>  
+
+    <ItemGroup Condition=" '$(GenerateAssemblyGuidAttributes)' == 'true' And '$(AssemblyGuid)' != '' ">
+      <AssemblyAttribute Include="System.Runtime.InteropServices.GuidAttribute">
+        <_Parameter1>$(AssemblyGuid)</_Parameter1>
+        <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
+      </AssemblyAttribute>
+    </ItemGroup>  
+
+    <ItemGroup Condition=" '$(GenerateAssemblyTrademarkAttributes)' == 'true' And '$(AssemblyTrademark)' != '' ">
+      <AssemblyAttribute Include="System.Reflection.AssemblyTrademarkAttribute">
+        <_Parameter1>$(AssemblyTrademark)</_Parameter1>
+        <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
+      </AssemblyAttribute>
+    </ItemGroup>  
+
+  </Target>
+
+  </Project>
+  

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -11,7 +11,7 @@
     <PackageType>MSBuildSdk</PackageType>
     <Product>MetaBrainz.Build</Product>
     <Title>MetaBrainz .NET SDK</Title>
-    <Version>3.0.1-pre</Version>
+    <Version>3.1.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MetaBrainz.Build.Sdk/Sdk.targets
+++ b/MetaBrainz.Build.Sdk/Sdk.targets
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
+  <Import Project="AssemblyInfo.targets" />
+
   <Import Project="NuGet.targets" />
 
   <Import Project="TreeStructure.targets" />


### PR DESCRIPTION
This adds generation of the following additional assembly attributes:

| Generation Property                    | Value Property         | Value            | Attribute                  |
|----------------------------------------|------------------------|------------------|----------------------------|
| GenerateAssemblyCLSCompliantAttributes | AssemblyIsCLSCompliant | `true` / `false` | `[CLSCompliant(...)]`      |
| GenerateAssemblyComVisibleAttributes   | AssemblyIsComVisible   | `true` / `false` | `[ComVisible(...)]`        |
| GenerateAssemblyCultureAttributes      | AssemblyCulture        | a culture ID     | `[AssemblyCulture(...)]`   |
| GenerateAssemblyGuidAttributes         | AssemblyGuid           | a UUID           | `[Guid(...)]`              |
| GenerateAssemblyTrademarkAttributes    | AssemblyTrademark      | text             | `[AssemblyTrademark(...)]` |

This also bumps the version up to 3.1.0-pre (because this is new "API").