### PR TITLE
Add API reference generation

### DIFF
--- a/MetaBrainz.Build.Sdk/ApiReference.props
+++ b/MetaBrainz.Build.Sdk/ApiReference.props
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <ApiReferenceFormat>cs-md</ApiReferenceFormat>
+    <ApiReferenceOutputDir>$([MSBuild]::NormalizeDirectory('$(MetaBrainzProjectRoot)', 'public-api'))</ApiReferenceOutputDir>
+    <ApiReferenceOutputExt>.$(TargetFramework).cs.md</ApiReferenceOutputExt>
+    <CreateApiReferenceOutputDir>true</CreateApiReferenceOutputDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Attributes to exclude from the API Reference. -->
+    <ApiReferenceExcludeAttribute Include="System.Diagnostics.DebuggableAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Diagnostics.DebuggerStepThroughAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.CompilationRelaxationsAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.RefSafetyRulesAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" />
+  </ItemGroup>
+
+</Project>

--- a/MetaBrainz.Build.Sdk/ApiReference.targets
+++ b/MetaBrainz.Build.Sdk/ApiReference.targets
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <GenerateApiReference Condition=" '$(GenerateApiReference)' == '' ">true</GenerateApiReference>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(GenerateApiReference)' == 'true' ">
+    <PackageReference Include="Zastai.Build.ApiReference" Version="2.0.1" IsImplicitlyDefined="true">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/MetaBrainz.Build.Sdk/Sdk.props
+++ b/MetaBrainz.Build.Sdk/Sdk.props
@@ -7,6 +7,8 @@
 
   <Import Project="CSharp.props" />
 
+  <Import Project="ApiReference.props" />
+
   <Import Project="NuGet.props" />
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/MetaBrainz.Build.Sdk/Sdk.targets
+++ b/MetaBrainz.Build.Sdk/Sdk.targets
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
+  <Import Project="ApiReference.targets" />
+
   <Import Project="AssemblyInfo.targets" />
 
   <Import Project="NuGet.targets" />


### PR DESCRIPTION
This uses the `Zastai.Build.ApiReference` package to generate API reference documentation as part of the build (unless explicitly disabled by setting `GenerateApiReference` to `false`).