### PR TITLE
Handle .snupkg files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: NuGet Packages (${{matrix.configuration}})
-        path: "output/package/${{matrix.configuration}}/*.nupkg"
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
       run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"

--- a/initial-project-contents/.github/workflows/build.yml
+++ b/initial-project-contents/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: NuGet Packages (${{matrix.configuration}})
-        path: "output/package/${{matrix.configuration}}/*.nupkg"
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
       run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
This uses `*.*nupkg` when uploading the artifacts in order to include the `.snupkg` files (if produced by the build).

The push actions are unchanged; the assumption is that package repositories with symbol support will trigger a push of the symbols package as part of the push of the main package.