### PR TITLE
Use sample contents for the initial `LICENSE.md`

### DIFF
--- a/initial-project-contents/LICENSE.md
+++ b/initial-project-contents/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 Tim Van Holder
+Copyright (c) YEAR(S) AUTHOR
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It now has "YEAR(S) OWNER" for the copyright line instead of specific values.