### PR TITLE
Minor updates

### DIFF
--- a/MetaBrainz.Build.Sdk/ApiReference.targets
+++ b/MetaBrainz.Build.Sdk/ApiReference.targets
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(GenerateApiReference)' == 'true' ">
-    <PackageReference Include="Zastai.Build.ApiReference" Version="2.0.1" IsImplicitlyDefined="true">
+    <PackageReference Include="Zastai.Build.ApiReference" Version="2.1.0" IsImplicitlyDefined="true">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/MetaBrainz.Build.Sdk/CSharp.props
+++ b/MetaBrainz.Build.Sdk/CSharp.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>11</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -5,7 +5,7 @@
     <Description>Build Support SDK for MetaBrainz C# Projects</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
     <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
-    <PackageCopyrightYears>2020, 2021, 2022, 2023</PackageCopyrightYears>
+    <PackageCopyrightYears>2020, 2021, 2022, 2023, 2024</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.Build</PackageRepositoryName>
     <PackageTags>MetaBrainz msbuild sdk</PackageTags>
     <PackageType>MSBuildSdk</PackageType>
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <!-- There's no actual code in this, but set a target anyway. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Enable C# 12, and update the API reference generation (without enabling any of the special enum handling).