### PR TITLE
Only target `net8.0`

### DIFF
--- a/MetaBrainz.Build.Sdk/Defaults.props
+++ b/MetaBrainz.Build.Sdk/Defaults.props
@@ -10,7 +10,7 @@
   <!-- Set up defaults for the frameworks to target. -->
   <PropertyGroup>
     <!-- We target the active LTS versions of .NET. No more .NET Core or .NET Framework. -->
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Set up the importance for debug messages issued by SDK targets. -->

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -15,11 +15,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- There's no actual code in this, but set a target anyway. -->
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <ContentTargetFolders>sdk</ContentTargetFolders>
     <IncludeContent>true</IncludeContent>
   </PropertyGroup>

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -11,7 +11,7 @@
     <PackageType>MSBuildSdk</PackageType>
     <Product>MetaBrainz.Build</Product>
     <Title>MetaBrainz .NET SDK</Title>
-    <Version>3.1.3-pre</Version>
+    <Version>4.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
.NET 6 is out of support, leaving `net8.0` as the only LTS target until .NET 10 is released next year.