### PR TITLE
GitHub action updates

### DIFF
--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -18,4 +18,3 @@ jobs:
           yaml-file: .github/github-labels.yml
           skip-delete: false
           dry-run: false
-          exclude:

--- a/initial-project-contents/.github/workflows/build.yml
+++ b/initial-project-contents/.github/workflows/build.yml
@@ -21,12 +21,13 @@ jobs:
 
     steps:
     - name: Check out the project
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set up .NET ${{env.dotnet-version}}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       id: setup
       with:
         dotnet-version: ${{env.dotnet-version}}
+        dotnet-quality: ga
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
@@ -34,19 +35,19 @@ jobs:
     - name: Run build script (${{matrix.configuration}})
       run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
     - name: "Artifact: MSBuild Logs"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: failure()
       with:
         name: MSBuild Logs (${{matrix.configuration}})
         path: msbuild.*.binlog
     - name: "Artifact: NuGet Packages"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: NuGet Packages (${{matrix.configuration}})
         path: "output/package/${{matrix.configuration}}/*.*nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
     - name: Publish (NuGet - nuget.org)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/initial-project-contents/.github/workflows/release-drafter.yml
+++ b/initial-project-contents/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.25.0
+      - uses: release-drafter/release-drafter@v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/initial-project-contents/.github/workflows/update-labels.yml
+++ b/initial-project-contents/.github/workflows/update-labels.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Labeler
@@ -18,4 +18,3 @@ jobs:
           yaml-file: .github/github-labels.yml
           skip-delete: false
           dry-run: false
-          exclude:


### PR DESCRIPTION
This removes the empty `exclude` section from update-labels.yml and updates the initial project contents to have up to date workflows:
- current versions of the various actions
- `--skip-duplicate` when pushing packages
