### PR TITLE
Update .NET version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      dotnet-version: 8.0.x
+      dotnet-version: 10.0.x
     strategy:
       matrix:
         configuration: ['Debug', 'Release']

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This file is automatically included by the build, at the top of each project. -->
 <Project>
 
   <!-- Chain to parent settings. -->

--- a/MetaBrainz.Build.Sdk/CSharp.props
+++ b/MetaBrainz.Build.Sdk/CSharp.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/MetaBrainz.Build.Sdk/Defaults.props
+++ b/MetaBrainz.Build.Sdk/Defaults.props
@@ -10,7 +10,7 @@
   <!-- Set up defaults for the frameworks to target. -->
   <PropertyGroup>
     <!-- We target the active LTS versions of .NET. No more .NET Core or .NET Framework. -->
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Set up the importance for debug messages issued by SDK targets. -->

--- a/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
+++ b/MetaBrainz.Build.Sdk/MetaBrainz.Build.Sdk.csproj
@@ -11,7 +11,7 @@
     <PackageType>MSBuildSdk</PackageType>
     <Product>MetaBrainz.Build</Product>
     <Title>MetaBrainz .NET SDK</Title>
-    <Version>4.0.1-pre</Version>
+    <Version>4.1.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MetaBrainz.Build.Sdk/Versioning.targets
+++ b/MetaBrainz.Build.Sdk/Versioning.targets
@@ -63,11 +63,6 @@
       <_BuildInfo />
       <_BuildPackageInfo />
     </PropertyGroup>
-    <!-- CI: AppVeyor -->
-    <PropertyGroup Condition=" '$(APPVEYOR)' == 'true' And '$(APPVEYOR_BUILD_NUMBER)' != '' ">
-      <_BuildInfo>AppVeyor build #$(APPVEYOR_BUILD_NUMBER)</_BuildInfo>
-      <_BuildPackageInfo>appveyor.$(APPVEYOR_BUILD_NUMBER)</_BuildPackageInfo>
-    </PropertyGroup>
     <!-- CI: GitHub Actions -->
     <PropertyGroup Condition=" '$(CI)' == 'true' And '$(GITHUB_ACTIONS)' == 'true' And '$(GITHUB_RUN_NUMBER)' != '' ">
       <_BuildInfo>GitHub build #$(GITHUB_RUN_NUMBER)</_BuildInfo>
@@ -146,7 +141,10 @@
 
   <PropertyGroup>
     <!-- This ensures the PackageVersion computation is run both when building a project's package and when resolving a project reference to a package reference. -->
-    <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn); _SetPackagePropertiesFromVersion</GetPackageVersionDependsOn>
+    <GetPackageVersionDependsOn>
+      $(GetPackageVersionDependsOn);
+      _SetPackagePropertiesFromVersion;
+    </GetPackageVersionDependsOn>
   </PropertyGroup>
 
   <Target Name="_SetPackagePropertiesFromVersion" DependsOnTargets="_GetVCSInfo; _GetBuildInfo; _ParseVersionSpecification" Condition=" '$(IsPackable)' != 'False' ">

--- a/initial-project-contents/.github/workflows/build.yml
+++ b/initial-project-contents/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      dotnet-version: 8.0.x
+      dotnet-version: 10.0.x
     strategy:
       matrix:
         configuration: ['Debug', 'Release']


### PR DESCRIPTION
Add .NET 10 to the targets and use C# 14.

Drop support for AppVeyor builds.